### PR TITLE
Update XFEL abbreviation (Official abbreviation is EuXFEL, not XFEL)

### DIFF
--- a/Participants/EuropeanXFEL.tex
+++ b/Participants/EuropeanXFEL.tex
@@ -1,5 +1,5 @@
-\begin{sitedescription}{XFEL}
-  \label{sitedescription:xfel}
+\begin{sitedescription}{EuXFEL}
+  \label{sitedescription:euxfel}
 
 % PIC:
 % see: http://ec.europa.eu/research/participants/portal/desktop/en/orga
@@ -7,13 +7,13 @@
 % See ../proposal.tex, section Members of the Consortium for a
 % complete description of what should go there
 
-  The European X-Ray Free-Electron Laser Facility GmbH is a limited
-  liability company under German law. At present, 11 countries are
-  supporting European XFEL through cash and in-kind contributions:
+  The European X-Ray Free-Electron Laser (EuXFEL) Facility GmbH is a
+  limited liability company under German law. At present, 11 countries
+  are supporting European XFEL through cash and in-kind contributions:
   Denmark, France, Germany, Hungary, Italy, Poland, Russia, Slovakia,
   Spain, Sweden, and Switzerland. The company is in charge of the
-  construction and operation of the European XFEL, a 3.4$\,$km long X-ray
-  free-electron laser facility extending from Hamburg to the
+  construction and operation of the European XFEL, a 3.4$\,$km long
+  X-ray free-electron laser facility extending from Hamburg to the
   neighbouring town of Schenefeld in the German federal state of
   Schleswig-Holstein. Civil construction started in early 2009; the
   beginning of user operation is planned for 2017. With its repetition

--- a/WApersons.tex
+++ b/WApersons.tex
@@ -9,9 +9,9 @@
         acronym=Simula]
         {Simula Research Laboratory}
 
-\WAinstitution[id=XFEL,
+\WAinstitution[id=EuXFEL,
         countryshort=DE,
-        acronym=XFEL]
+        acronym=EuXFEL]
         {European XFEL GmbH}
 
 \WAinstitution[id=QS,

--- a/WorkPackages/applications.tex
+++ b/WorkPackages/applications.tex
@@ -24,7 +24,7 @@ once completed)}
   UIORM=24,
   UPSUDRM=12,
   WTTRM=6,
-  XFELRM=36,
+  EuXFELRM=36,
 ]
 \begin{wpobjectives}
  \begin{compactitem}

--- a/WorkPackages/education.tex
+++ b/WorkPackages/education.tex
@@ -24,7 +24,7 @@ once completed)}
   UIORM=4,
   UPSUDRM=16,
   % WTTRM=4,
-  XFELRM=8,
+  EuXFELRM=8,
 ]
 \begin{wpobjectives}
  \begin{compactitem}

--- a/WorkPackages/eosc.tex
+++ b/WorkPackages/eosc.tex
@@ -24,7 +24,7 @@ once completed)}
   % UIORM=4,
   UPSUDRM=4,
   WTTRM=6,
-  XFELRM=6,
+  EuXFELRM=6,
 ]
 \begin{wpobjectives}
  \begin{compactitem}

--- a/WorkPackages/jupyter-core.tex
+++ b/WorkPackages/jupyter-core.tex
@@ -24,7 +24,7 @@ once completed)}
   % UIORM=4,
   UPSUDRM=16,
   WTTRM=6,
-  XFELRM=18,
+  EuXFELRM=18,
 ]
 \begin{wpobjectives}
   \begin{compactitem}

--- a/WorkPackages/jupyter-ecosystem.tex
+++ b/WorkPackages/jupyter-ecosystem.tex
@@ -24,7 +24,7 @@ once completed)}
   % UIORM=4,
   % UPSUDRM=4,
   WTTRM=12,
-  XFELRM=54,
+  EuXFELRM=54,
 ]
 \begin{wpobjectives}
  \begin{compactitem}

--- a/WorkPackages/management.tex
+++ b/WorkPackages/management.tex
@@ -24,7 +24,7 @@ once completed)}
   UIORM=4,
   UPSUDRM=4,
   WTTRM=4,
-  XFELRM=4,
+  EuXFELRM=4,
   swsites
 ]
 \begin{wpobjectives}

--- a/proposal.tex
+++ b/proposal.tex
@@ -45,7 +45,7 @@
   % TODO: Nicolas needs to update these numbers from the (requested ones)
   site=UPSUD, %paris sud
   site=SRL, % Simula
-  site=XFEL, % European XFEL GmbH
+  site=EuXFEL, % European XFEL GmbH
   site=QS, % QuantStack
   site=SIL, % U Silesia
   site=WTT, % WildTreeTech

--- a/tasks/jupyterhub.tex
+++ b/tasks/jupyterhub.tex
@@ -6,7 +6,7 @@
   lead=SRL,
   PM=2,
   wphases={0-48},
-  partners={SRL,XFEL}
+  partners={SRL,EuXFEL}
 ]
   Developing the core JupyterHub framework for is key to ...
   The task includes the following activities

--- a/tasks/r2d-and-binder.tex
+++ b/tasks/r2d-and-binder.tex
@@ -6,7 +6,7 @@
   lead=SRL,
   PM=48,
   wphases={0-48},
-  partners={XFEL,XXX}
+  partners={EuXFEL,XXX}
 ]
   The task includes the following activities
   \begin{compactitem}

--- a/tasks/reproducibility-xfel.tex
+++ b/tasks/reproducibility-xfel.tex
@@ -2,8 +2,8 @@
 % each task should be added to exactly one workpackage
 % in the workpackage task list
 \begin{task}[title=Reproducible X-ray crystallography workflows at European XFEL,
-  id=reproducibility-xfel,
-  lead=XFEL,
+  id=reproducibility-euxfel,
+  lead=EuXFEL,
   PM=36,
   wphases={0-48},
   partners={}

--- a/tasks/reproducibility.tex
+++ b/tasks/reproducibility.tex
@@ -3,7 +3,7 @@
 % in the workpackage task list
 \begin{task}[title=Archiving software for reproducible workflows,
   id=reproducibility,
-  lead=XFEL,
+  lead=EuXFEL,
   PM=36,
   wphases={0-48},
   partners={}

--- a/tasks/widgets.tex
+++ b/tasks/widgets.tex
@@ -6,7 +6,7 @@
   lead=XXX,
   PM=48,
   wphases={0-48},
-  partners={XFEL,QS}
+  partners={EuXFEL,QS}
 ]
   The task includes the following activities
   \begin{compactitem}


### PR DESCRIPTION
I have stuck to the funny capitalisation (EuXFEL), apart from places
where we have used 'xfel' in lower case before [section names etc],
where I have replaced this with 'euxfel'.

Resulted in extra line wrapping in some places.