### PR TITLE
Update the EU Binder task

### DIFF
--- a/WorkPackages/eosc.tex
+++ b/WorkPackages/eosc.tex
@@ -30,16 +30,31 @@ once completed)}
 ]
 \begin{wpobjectives}
  \begin{compactitem}
-   \item operate services for open science
-   \item migrate services to EOSC
+   \item to support and develop BinderHub infrastructure based in the EU for
+     science and education applications
+   \item to scale this service by migrating to EOSC
  \end{compactitem}
 \end{wpobjectives}
 
 \begin{wpdescription}
 
-This work package is about the actual operation of services developed in the other work packages.
+This work package is focussed on developing and operating a publicly accessible
+BinderHub service based in the EU.
 
-\TOWRITE{MORE}
+The team of Project Binder provide a service at https://mybinder.org
+which is public infrastructure powered by the software they develop.
+mybinder.org is used to launch around 80000 "binders" every week and is
+being used by researchers and teachers to make their work reproducible.
+
+Although mybinder.org is very popular, there are currently only two
+additional public BinderHubs worldwide. This means that there is a limited
+expertise in operating and maintaining such public infrastructure.
+
+In particular, we will help maintain the tools and documentation required
+to operate public infrastructure like Binder to meet the needs of the
+open-science community in the EU. In addition we will develop new features
+for the BinderHub project that will bring it to a wider audience and improve
+its usefulness for scientists based in the EU.
 
 \end{wpdescription}
 
@@ -54,6 +69,13 @@ This work package is about the actual operation of services developed in the oth
 \begin{wpdelivs}
   \begin{wpdeliv}[due=18,miles=startup,id=openstack-openshift-documentation,dissem=PU,nature=R,lead=EP]
     {Documentation of how to deploy easily JupyterHub and BinderHub on OpenStack and OpenShift}
+  \end{wpdeliv}
+  \begin{wpdeliv}[due=24,miles=prototype,id=eu-binder-instance,dissem=PU,nature=R,lead=SRL]
+    {Documentation and tools of how to easily deploy a public BinderHub on EU
+    cloud infrastructure}
+  \end{wpdeliv}
+  \begin{wpdeliv}[due=36,miles=community,id=binder-federation,dissem=PU,nature=R,lead=SRL]
+    {Documentation on best-practices of operating a federation of BinderHubs}
   \end{wpdeliv}
 \end{wpdelivs}
 \end{workpackage}

--- a/tasks/eu-binder.tex
+++ b/tasks/eu-binder.tex
@@ -9,14 +9,6 @@
   wphases={0-48},
   partners={SRL,EGI,WTT,UPSUD}
 ]
-  The team of Project Binder provide a service: https://mybinder.org
-  which is public infrastructure powered by the software they develop.
-  mybinder.org is used to launch around 80000 "binders" every week and is
-  being used by researchers and teachers to make their work reproducible.
-
-  Although mybinder.org is very popular, there are currently only two
-  additional public BinderHubs worldwide. This means that there is a limited
-  expertise in operating and maintaining such public infrastructure.
 
   The purpose of this task is to create a community of practice of BinderHub
   operators and operate a European Binder instance.
@@ -35,20 +27,15 @@
   global federation of Binder instances.
 
 
-  %% In 2018 around 2.5million "binders" were launched. In one week of August
-  %% around 350 different repositories were launched in a single week. These
-  %% numbers show that mybinder.org (and the technology behind it) is seeing fast
-  %% adoption in the research and teaching community.
-
-
   \begin{compactitem}
   \item Build a community of practice of BinderHub operators. Create a forum
-  for Binder operators to exchange experience and tools. Create a report on
-  best practices for operation (SRE guide).
-  \item Operating a Binder instance in Europe. Find a hoster, use work from
-  deployment task, deploy and operate eu.mybinder.org, 
-  \item Develop a federation of Binder instances. Leverage the community of
-  practice. Solve technical challenges related to federation.
-    (\localdelivref{deliv-id})
+  for Binder operators to exchange experience and tools.
+
+  \item Operate a Binder instance hosted in Europe.
+
+  \item Develop a federation of Binder instances and produce a report on best
+    practices for coordinating several federated BinderHub instances across
+    institutes.
+    (\localdelivref{eu-binder-instance})
   \end{compactitem}
 \end{task}


### PR DESCRIPTION
The integration with EOSC is still a bit of a mystery to me. The EOSC website just seems to be a catalogue not a cloud service provider like GC or AWS. Maybe integration with EOSC just means listing Binder as a service in the catalogue?